### PR TITLE
Initial attempt at supporting collections of arbitrary types as keys

### DIFF
--- a/src/trie.jl
+++ b/src/trie.jl
@@ -1,25 +1,27 @@
-mutable struct Trie{T}
-    value::T
-    children::Dict{Char,Trie{T}}
+const TrieKey = Union{AbstractString, AbstractVector}
+
+mutable struct Trie{K, V, E}
+    value::V
+    children::Dict{E, Trie{K, V, E}}
     is_key::Bool
 
-    function Trie{T}() where T
-        self = new{T}()
-        self.children = Dict{Char,Trie{T}}()
+    function Trie{K, V, E}() where {K, V, E}
+        self = new{K, V, E}()
+        self.children = Dict{E, Trie{K, V, E}}()
         self.is_key = false
         self
     end
 
-    function Trie{T}(ks, vs) where T
-        t = Trie{T}()
+    function Trie{K, V, E}(ks, vs) where {K, V, E}
+        t = Trie{K, V, E}()
         for (k, v) in zip(ks, vs)
             t[k] = v
         end
         return t
     end
 
-    function Trie{T}(kv) where T
-        t = Trie{T}()
+    function Trie{K, V, E}(kv) where {K, V, E}
+        t = Trie{K, V, E}()
         for (k,v) in kv
             t[k] = v
         end
@@ -27,17 +29,22 @@ mutable struct Trie{T}
     end
 end
 
-Trie() = Trie{Any}()
-Trie(ks::AbstractVector{K}, vs::AbstractVector{V}) where {K<:AbstractString,V} = Trie{V}(ks, vs)
-Trie(kv::AbstractVector{Tuple{K,V}}) where {K<:AbstractString,V} = Trie{V}(kv)
-Trie(kv::AbstractDict{K,V}) where {K<:AbstractString,V} = Trie{V}(kv)
-Trie(ks::AbstractVector{K}) where {K<:AbstractString} = Trie{Nothing}(ks, similar(ks, Nothing))
+Trie() = Trie{String, Any, Char}()
+Trie(K::Type) = Trie{K, Any, eltype(K)}()
+Trie(K::Type, V::Type) = Trie{K, V, eltype(K)}()
 
-function setindex!(t::Trie{T}, val::T, key::AbstractString) where T
+Trie(ks::AbstractVector{K}, vs::AbstractVector{V}) where {K<:TrieKey, V} =
+    Trie{K, V, eltype(K)}(ks, vs)
+Trie(kv::AbstractVector{Tuple{K,V}}) where {K<:TrieKey, V} = Trie{K, V, eltype(K)}(kv)
+Trie(kv::AbstractDict{K,V}) where {K<:TrieKey, V} = Trie{K, V, eltype(K)}(kv)
+Trie(ks::AbstractVector{K}) where {K<:TrieKey} =
+    Trie{K, Nothing, eltype(K)}(ks, similar(ks, Nothing))
+
+function setindex!(t::Trie{K, V}, val::V, key::K) where {K, V}
     node = t
     for char in key
         if !haskey(node.children, char)
-            node.children[char] = Trie{T}()
+            node.children[char] = Trie(K, V)
         end
         node = node.children[char]
     end
@@ -45,7 +52,7 @@ function setindex!(t::Trie{T}, val::T, key::AbstractString) where T
     node.value = val
 end
 
-function getindex(t::Trie, key::AbstractString)
+function getindex(t::Trie, key)
     node = subtrie(t, key)
     if node != nothing && node.is_key
         return node.value
@@ -53,24 +60,24 @@ function getindex(t::Trie, key::AbstractString)
     throw(KeyError("key not found: $key"))
 end
 
-function subtrie(t::Trie, prefix::AbstractString)
+function subtrie(t::Trie, prefix)
     node = t
-    for char in prefix
-        if !haskey(node.children, char)
+    for k in prefix
+        if !haskey(node.children, k)
             return nothing
         else
-            node = node.children[char]
+            node = node.children[k]
         end
     end
     node
 end
 
-function haskey(t::Trie, key::AbstractString)
+function haskey(t::Trie, key)
     node = subtrie(t, key)
     node != nothing && node.is_key
 end
 
-function get(t::Trie, key::AbstractString, notfound)
+function get(t::Trie, key, notfound)
     node = subtrie(t, key)
     if node != nothing && node.is_key
         return node.value
@@ -78,29 +85,39 @@ function get(t::Trie, key::AbstractString, notfound)
     notfound
 end
 
-function keys(t::Trie, prefix::AbstractString="", found=AbstractString[])
+keys(t::Trie{K}) where {K<:AbstractString} = keys(t, "", K[])
+keys(t::Trie{K}) where {K<:AbstractVector} = keys(t, K(), K[])
+
+function keys(t::Trie, prefix, found)
     if t.is_key
         push!(found, prefix)
     end
-    for (char,child) in t.children
-        keys(child, string(prefix,char), found)
+
+    for (k, child) in t.children
+        keys(child, append_key(prefix, k), found)
     end
     found
 end
 
-function keys_with_prefix(t::Trie, prefix::AbstractString)
+# I was here!
+function keys_with_prefix(t::Trie{K}, prefix::K) where {K}
     st = subtrie(t, prefix)
-    st != nothing ? keys(st,prefix) : []
+    st != nothing ? keys(st, prefix, Vector{K}()) : Vector{K}()
 end
+
+# We special appending a value to the prefix as this will be different for
+# strings and arrays.
+append_key(prefix::AbstractString, x::Char) = string(prefix, x)
+append_key(prefix::AbstractVector{T}, x::T) where {T} = vcat(prefix, x)
 
 # The state of a TrieIterator is a pair (t::Trie, i::Int),
 # where t is the Trie which was the output of the previous iteration
 # and i is the index of the current character of the string.
 # The indexing is potentially confusing;
 # see the comments and implementation below for details.
-struct TrieIterator
-    t::Trie
-    str::AbstractString
+struct TrieIterator{K}
+    t::Trie{K}
+    key::K
 end
 
 # At the start, there is no previous iteration,
@@ -114,16 +131,16 @@ function next(it::TrieIterator, state)
     t, i = state
     i == 0 && return it.t, (it.t, 1)
 
-    t = t.children[it.str[i]]
+    t = t.children[it.key[i]]
     return (t, (t, i + 1))
 end
 
 function done(it::TrieIterator, state)
     t, i = state
     i == 0 && return false
-    i == length(it.str) + 1 && return true
-    return !(it.str[i] in keys(t.children))
+    i == length(it.key) + 1 && return true
+    return !(it.key[i] in keys(t.children))
 end
 
-path(t::Trie, str::AbstractString) = TrieIterator(t, str)
-Base.iteratorsize(::Type{TrieIterator}) = Base.SizeUnknown()
+path(t::Trie{K}, key::K) where {K} = TrieIterator(t, key)
+Base.iteratorsize(::Type{<:TrieIterator}) = Base.SizeUnknown()

--- a/test/test_trie.jl
+++ b/test/test_trie.jl
@@ -2,40 +2,132 @@
 
 @testset "Trie" begin
 
-    t=Trie{Int}()
+    @testset "String Keys" begin
+        t=Trie(String, Int)
 
-    t["amy"]=56
-    t["ann"]=15
-    t["emma"]=30
-    t["rob"]=27
-    t["roger"]=52
+        t["amy"]=56
+        t["ann"]=15
+        t["emma"]=30
+        t["rob"]=27
+        t["roger"]=52
 
-    @test haskey(t, "roger")
-    @test get(t,"rob",nothing) == 27
-    @test sort(keys(t)) == ["amy", "ann", "emma", "rob", "roger"]
-    @test t["rob"] == 27
-    @test sort(keys_with_prefix(t,"ro")) == ["rob", "roger"]
-
-
-    # constructors
-    ks = ["amy", "ann", "emma", "rob", "roger"]
-    vs = [56, 15, 30, 27, 52]
-    kvs = collect(zip(ks, vs))
-    @test isa(Trie(ks, vs), Trie{Int})
-    @test isa(Trie(kvs), Trie{Int})
-    @test isa(Trie(Dict(kvs)), Trie{Int})
-    @test isa(Trie(ks), Trie{Nothing})
+        @test haskey(t, "roger")
+        @test get(t,"rob",nothing) == 27
+        @test sort(keys(t)) == ["amy", "ann", "emma", "rob", "roger"]
+        @test t["rob"] == 27
+        @test sort(keys_with_prefix(t,"ro")) == ["rob", "roger"]
 
 
-    # path iterator
-    t0 = t
-    t1 = t0.children['r']
-    t2 = t1.children['o']
-    t3 = t2.children['b']
-    @test collect(path(t, "b")) == [t0]
-    @test collect(path(t, "rob")) == [t0, t1, t2, t3]
-    @test collect(path(t, "robb")) == [t0, t1, t2, t3]
-    @test collect(path(t, "ro")) == [t0, t1, t2]
-    @test collect(path(t, "roa")) == [t0, t1, t2]
+        # constructors
+        ks = ["amy", "ann", "emma", "rob", "roger"]
+        vs = [56, 15, 30, 27, 52]
+        kvs = collect(zip(ks, vs))
+        @test isa(Trie(ks, vs), Trie{String, Int})
+        @test isa(Trie(kvs), Trie{String, Int})
+        @test isa(Trie(Dict(kvs)), Trie{String, Int})
+        @test isa(Trie(ks), Trie{String, Nothing})
 
+
+        # path iterator
+        t0 = t
+        t1 = t0.children['r']
+        t2 = t1.children['o']
+        t3 = t2.children['b']
+        @test collect(path(t, "b")) == [t0]
+        @test collect(path(t, "rob")) == [t0, t1, t2, t3]
+        @test collect(path(t, "robb")) == [t0, t1, t2, t3]
+        @test collect(path(t, "ro")) == [t0, t1, t2]
+        @test collect(path(t, "roa")) == [t0, t1, t2]
+    end
+
+    @testset "Symbol Vector Keys" begin
+        t = Trie(Vector{Symbol}, Int)
+
+        ks = [
+            [:a, :m, :y],
+            [:a, :n, :n],
+            [:e, :m, :m, :a],
+            [:r, :o, :b],
+            [:r, :o, :g, :e, :r],
+        ]
+
+        vs = [56, 15, 30, 27, 52]
+
+        t[[:a, :m, :y]] = 56
+        t[[:a, :n, :n]] = 15
+        t[[:e, :m, :m, :a]] = 30
+        t[[:r, :o, :b]] = 27
+        t[[:r, :o, :g, :e, :r]] = 52
+
+        @test haskey(t, [:r, :o, :g, :e, :r])
+        @test get(t, [:r, :o, :b], nothing) == 27
+        @test Set(keys(t)) == Set(ks)
+
+        @test t[[:r, :o, :b]] == 27
+        @test Set(keys_with_prefix(t, [:r, :o])) == Set([[:r, :o, :b], [:r, :o, :g, :e, :r]])
+
+        # constructors
+        kvs = collect(zip(ks, vs))
+        @test isa(Trie(ks, vs), Trie{Vector{Symbol}, Int})
+        @test isa(Trie(kvs), Trie{Vector{Symbol}, Int})
+        @test isa(Trie(Dict(kvs)), Trie{Vector{Symbol}, Int})
+        @test isa(Trie(ks), Trie{Vector{Symbol}, Nothing})
+
+        # path iterator
+        t0 = t
+        t1 = t0.children[:r]
+        t2 = t1.children[:o]
+        t3 = t2.children[:b]
+        @test collect(path(t, [:b])) == [t0]
+        @test collect(path(t, [:r, :o, :b])) == [t0, t1, t2, t3]
+        @test collect(path(t, [:r, :o, :b, :b])) == [t0, t1, t2, t3]
+        @test collect(path(t, [:r, :o])) == [t0, t1, t2]
+        @test collect(path(t, [:r, :o, :a])) == [t0, t1, t2]
+    end
+
+    @testset "UInt8 Vector Keys" begin
+        t = Trie(Vector{UInt8}, Int)
+
+        # We're using strings as the source of the Vector{UInt8} data just to
+        # help with test readability.
+        amy = Vector{UInt8}("amy")
+        ann = Vector{UInt8}("ann")
+        emma = Vector{UInt8}("emma")
+        rob = Vector{UInt8}("rob")
+        roger = Vector{UInt8}("roger")
+
+        ks = [amy, ann, emma, rob, roger]
+        vs = [56, 15, 30, 27, 52]
+
+        t[amy] = 56
+        t[ann] = 15
+        t[emma] = 30
+        t[rob] = 27
+        t[roger] = 52
+
+        @test haskey(t, roger)
+        @test get(t, rob, nothing) == 27
+        @test Set(keys(t)) == Set(ks)
+
+        @test t[rob] == 27
+        @test Set(keys_with_prefix(t, Vector{UInt8}("ro"))) == Set([rob, roger])
+
+        # constructors
+        kvs = collect(zip(ks, vs))
+        @test isa(Trie(ks, vs), Trie{Vector{UInt8}, Int})
+        @test isa(Trie(kvs), Trie{Vector{UInt8}, Int})
+        @test isa(Trie(Dict(kvs)), Trie{Vector{UInt8}, Int})
+        @test isa(Trie(ks), Trie{Vector{UInt8}, Nothing})
+
+        # path iterator
+        t0 = t
+        t1 = t0.children[UInt8('r')]
+        t2 = t1.children[UInt8('o')]
+        t3 = t2.children[UInt8('b')]
+        @test collect(path(t, Vector{UInt8}("b"))) == [t0]
+        @test collect(path(t, rob)) == [t0, t1, t2, t3]
+        @test collect(path(t, Vector{UInt8}("robb"))) == [t0, t1, t2, t3]
+        @test collect(path(t, Vector{UInt8}("ro"))) == [t0, t1, t2]
+        @test collect(path(t, Vector{UInt8}("roa"))) == [t0, t1, t2]
+    end
 end # @testset Trie


### PR DESCRIPTION
- Keys can now be an `AbstractString` or `Vector{T}`.
- Needed to adjust the parameterization of the `Trie` type and some of its constructors.
- Added some tests for `Vector{Symbol}` and `Vector{UInt8}` keys.